### PR TITLE
Add Time class to get current time

### DIFF
--- a/10-hands-on-lab/permit-dashboard/app.py
+++ b/10-hands-on-lab/permit-dashboard/app.py
@@ -82,6 +82,15 @@ page = st.sidebar.radio(
     ["🏠 Home", "📊 Analytics", "📋 Permit Tracker", "📈 Trends", "ℹ️ About"]
 )
 
+class Time:
+    def get_time(self):
+        import datetime
+        t = datetime.datetime.now()
+        return str(t.hour) + ":" + str(t.minute) + ":" + str(t.second)
+
+t = Time()
+print(t.get_time())
+
 # Load data
 df = generate_permit_data()
 


### PR DESCRIPTION
This pull request introduces a new utility class for retrieving and printing the current time. The main change is the addition of the `Time` class and its usage, which is currently used to print the current time to the console.

New utility class:

* Added a `Time` class with a `get_time` method that returns the current time as a string, and printed the current time using this class in `app.py`.